### PR TITLE
Translate extension name when no replication is needed

### DIFF
--- a/include/dxc/HLSL/HLOperationLowerExtension.h
+++ b/include/dxc/HLSL/HLOperationLowerExtension.h
@@ -77,19 +77,5 @@ namespace hlsl {
     llvm::Value *Replicate(llvm::CallInst *CI);
     llvm::Value *Pack(llvm::CallInst *CI);
     llvm::Value *Resource(llvm::CallInst *CI);
-
-    // Translate the HL call by replicating the call for each vector element.
-    //
-    // For example,
-    //
-    //    <2xi32> %r = call @ext.foo(i32 %op, <2xi32> %v)
-    //    ==>
-    //    %r.1 = call @ext.foo.s(i32 %op, i32 %v.1)
-    //    %r.2 = call @ext.foo.s(i32 %op, i32 %v.2)
-    //    <2xi32> %r.v.1 = insertelement %r.1, 0, <2xi32> undef
-    //    <2xi32> %r.v.2 = insertelement %r.2, 1, %r.v.1
-    //
-    // You can then RAWU %r with %r.v.2. The RAWU is not done by the translate function.
-    static llvm::Value *TranslateReplicating(llvm::CallInst *CI, llvm::Function *ReplicatedFunction);
   };
 }

--- a/tools/clang/unittests/HLSL/ExtensionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExtensionTest.cpp
@@ -403,6 +403,7 @@ public:
   TEST_METHOD(ReplicateLoweringWhenOnlyVectorIsResult);
   TEST_METHOD(UnsignedOpcodeIsUnchanged);
   TEST_METHOD(ResourceExtensionIntrinsic);
+  TEST_METHOD(NameLoweredWhenNoReplicationNeeded);
 };
 
 TEST_F(ExtensionTest, DefineWhenRegisteredThenPreserved) {
@@ -723,4 +724,23 @@ TEST_F(ExtensionTest, ResourceExtensionIntrinsic) {
   std::string regexErrors;
   VERIFY_IS_TRUE(regex.isValid(regexErrors));
   VERIFY_IS_TRUE(regex.match(disassembly));
+}
+
+TEST_F(ExtensionTest, NameLoweredWhenNoReplicationNeeded) {
+  Compiler c(m_dllSupport);
+  c.RegisterIntrinsicTable(new TestIntrinsicTable());
+  c.Compile(
+    "int main(int v1 : V1) : SV_Target {\n"
+    "  return test_int(v1);\n"
+    "}\n",
+    { L"/Vd" }, {}
+  );
+  std::string disassembly = c.Disassemble();
+
+  // Make sure the name is still lowered even when no replication
+  // is needed because a non-vector overload of the function
+  // was used.
+  VERIFY_IS_TRUE(
+    disassembly.npos !=
+    disassembly.find("call i32 @test_int("));
 }


### PR DESCRIPTION
Previously, If an extension uses the replication lowering strategy
and a non-vector overload was chosen we would return the function
un-modified. This change makes sure that we still use the
custom lowering name for the extension if one was specified.